### PR TITLE
WEB-705 - Add `Worldwide` to the list of countries

### DIFF
--- a/country-iso2.json
+++ b/country-iso2.json
@@ -1,1010 +1,1014 @@
 [
- {
-   "name":"Afghanistan",
-   "value":"AF"
- },
- {
-   "name":"Åland Islands",
-   "value":"AX"
- },
- {
-   "name":"Albania",
-   "value":"AL"
- },
- {
-   "name":"Algeria",
-   "value":"DZ"
- },
- {
-   "name":"American Samoa",
-   "value":"AS"
- },
- {
-   "name":"Andorra",
-   "value":"AD"
- },
- {
-   "name":"Angola",
-   "value":"AO"
- },
- {
-   "name":"Anguilla",
-   "value":"AI"
- },
- {
-   "name":"Antarctica",
-   "value":"AQ"
- },
- {
-   "name":"Antigua And Barbuda",
-   "value":"AG"
- },
- {
-   "name":"Argentina",
-   "value":"AR"
- },
- {
-   "name":"Armenia",
-   "value":"AM"
- },
- {
-   "name":"Aruba",
-   "value":"AW"
- },
- {
-   "name":"Ascension Island",
-   "value":"AC"
- },
- {
-   "name":"Australia",
-   "value":"AU"
- },
- {
-   "name":"Austria",
-   "value":"AT"
- },
- {
-   "name":"Azerbaijan",
-   "value":"AZ"
- },
- {
-   "name":"Bahamas",
-   "value":"BS"
- },
- {
-   "name":"Bahrain",
-   "value":"BH"
- },
- {
-   "name":"Bangladesh",
-   "value":"BD"
- },
- {
-   "name":"Barbados",
-   "value":"BB"
- },
- {
-   "name":"Belarus",
-   "value":"BY"
- },
- {
-   "name":"Belgium",
-   "value":"BE"
- },
- {
-   "name":"Belize",
-   "value":"BZ"
- },
- {
-   "name":"Benin",
-   "value":"BJ"
- },
- {
-   "name":"Bermuda",
-   "value":"BM"
- },
- {
-   "name":"Bhutan",
-   "value":"BT"
- },
- {
-   "name":"Bolivia",
-   "value":"BO"
- },
- {
-   "name":"Bosnia And Herzegovina",
-   "value":"BA"
- },
- {
-   "name":"Botswana",
-   "value":"BW"
- },
- {
-   "name":"Bouvet Island",
-   "value":"BV"
- },
- {
-   "name":"Brazil",
-   "value":"BR"
- },
- {
-   "name":"British Indian Ocean Territory",
-   "value":"IO"
- },
- {
-   "name":"British Virgin Islands",
-   "value":"VG"
- },
- {
-   "name":"Brunei Darussalam",
-   "value":"BN"
- },
- {
-   "name":"Bulgaria",
-   "value":"BG"
- },
- {
-   "name":"Burkina Faso",
-   "value":"BF"
- },
- {
-   "name":"Burma",
-   "value":"MM"
- },
- {
-   "name":"Burundi",
-   "value":"BI"
- },
- {
-   "name":"Cambodia",
-   "value":"KH"
- },
- {
-   "name":"Cameroon",
-   "value":"CM"
- },
- {
-   "name":"Canada",
-   "value":"CA"
- },
- {
-   "name":"Canary Islands",
-   "value":"IC"
- },
- {
-   "name":"Cape Verde",
-   "value":"CV"
- },
- {
-   "name":"Cayman Islands",
-   "value":"KY"
- },
- {
-   "name":"Central African Republic",
-   "value":"CF"
- },
- {
-   "name":"Chad",
-   "value":"TD"
- },
- {
-   "name":"Chile",
-   "value":"CL"
- },
- {
-   "name":"China",
-   "value":"CN"
- },
- {
-   "name":"Christmas Island",
-   "value":"CX"
- },
- {
-   "name":"Cocos (keeling) Islands",
-   "value":"CC"
- },
- {
-   "name":"Colombia",
-   "value":"CO"
- },
- {
-   "name":"Comoros",
-   "value":"KM"
- },
- {
-   "name":"Congo",
-   "value":"CG"
- },
- {
-   "name":"Congo, The Democratic Republic Of The",
-   "value":"CD"
- },
- {
-   "name":"Cook Islands",
-   "value":"CK"
- },
- {
-   "name":"Costa Rica",
-   "value":"CR"
- },
- {
-   "name":"CÔte D'ivoire",
-   "value":"CI"
- },
- {
-   "name":"Croatia",
-   "value":"HR"
- },
- {
-   "name":"Cuba",
-   "value":"CU"
- },
- {
-   "name":"Cyprus",
-   "value":"CY"
- },
- {
-   "name":"Czech Republic",
-   "value":"CZ"
- },
- {
-   "name":"Denmark",
-   "value":"DK"
- },
- {
-   "name":"Diego Garcia",
-   "value":"DG"
- },
- {
-   "name":"Djibouti",
-   "value":"DJ"
- },
- {
-   "name":"Dominica",
-   "value":"DM"
- },
- {
-   "name":"Dominican Republic",
-   "value":"DO"
- },
- {
-   "name":"East Timor",
-   "value":"TL"
- },
- {
-   "name":"Ecuador",
-   "value":"EC"
- },
- {
-   "name":"Egypt",
-   "value":"EG"
- },
- {
-   "name":"El Salvador",
-   "value":"SV"
- },
- {
-   "name":"Equatorial Guinea",
-   "value":"GQ"
- },
- {
-   "name":"Eritrea",
-   "value":"ER"
- },
- {
-   "name":"Estonia",
-   "value":"EE"
- },
- {
-   "name":"Ethiopia",
-   "value":"ET"
- },
- {
-   "name":"European Union",
-   "value":"EU"
- },
- {
-   "name":"Falkland Islands (malvinas)",
-   "value":"FK"
- },
- {
-   "name":"Faroe Islands",
-   "value":"FO"
- },
- {
-   "name":"Fiji",
-   "value":"FJ"
- },
- {
-   "name":"Finland",
-   "value":"FI"
- },
- {
-   "name":"France",
-   "value":"FR"
- },
- {
-   "name":"French Guiana",
-   "value":"GF"
- },
- {
-   "name":"French Polynesia",
-   "value":"PF"
- },
- {
-   "name":"French Southern Territories",
-   "value":"TF"
- },
- {
-   "name":"Gabon",
-   "value":"GA"
- },
- {
-   "name":"Georgia",
-   "value":"GE"
- },
- {
-   "name":"Germany",
-   "value":"DE"
- },
- {
-   "name":"Ghana",
-   "value":"GH"
- },
- {
-   "name":"Gibraltar",
-   "value":"GI"
- },
- {
-   "name":"Greece",
-   "value":"GR"
- },
- {
-   "name":"Greenland",
-   "value":"GL"
- },
- {
-   "name":"Grenada",
-   "value":"GD"
- },
- {
-   "name":"Guadeloupe",
-   "value":"GP"
- },
- {
-   "name":"Guam",
-   "value":"GU"
- },
- {
-   "name":"Guatemala",
-   "value":"GT"
- },
- {
-   "name":"Guernsey",
-   "value":"GG"
- },
- {
-   "name":"Guinea",
-   "value":"GN"
- },
- {
-   "name":"Guinea-Bissau",
-   "value":"GW"
- },
- {
-   "name":"Guyana",
-   "value":"GY"
- },
- {
-   "name":"Haiti",
-   "value":"HT"
- },
- {
-   "name":"Heard Island And Mcdonald Islands",
-   "value":"HM"
- },
- {
-   "name":"Honduras",
-   "value":"HN"
- },
- {
-   "name":"Hong Kong",
-   "value":"HK"
- },
- {
-   "name":"Hungary",
-   "value":"HU"
- },
- {
-   "name":"Iceland",
-   "value":"IS"
- },
- {
-   "name":"India",
-   "value":"IN"
- },
- {
-   "name":"Indonesia",
-   "value":"ID"
- },
- {
-   "name":"Iran",
-   "value":"IR"
- },
- {
-   "name":"Iraq",
-   "value":"IQ"
- },
- {
-   "name":"Ireland",
-   "value":"IE"
- },
- {
-   "name":"Isle Of Man",
-   "value":"IM"
- },
- {
-   "name":"Israel",
-   "value":"IL"
- },
- {
-   "name":"Italy",
-   "value":"IT"
- },
- {
-   "name":"Jamaica",
-   "value":"JM"
- },
- {
-   "name":"Japan",
-   "value":"JP"
- },
- {
-   "name":"Jersey",
-   "value":"JE"
- },
- {
-   "name":"Jordan",
-   "value":"JO"
- },
- {
-   "name":"Kazakhstan",
-   "value":"KZ"
- },
- {
-   "name":"Kenya",
-   "value":"KE"
- },
- {
-   "name":"Kiribati",
-   "value":"KI"
- },
- {
-   "name":"Kosovo",
-   "value":"XK"
- },
- {
-   "name":"Kuwait",
-   "value":"KW"
- },
- {
-   "name":"Kyrgyzstan",
-   "value":"KG"
- },
- {
-   "name":"Lao People's Democratic Republic",
-   "value":"LA"
- },
- {
-   "name":"Latvia",
-   "value":"LV"
- },
- {
-   "name":"Lebanon",
-   "value":"LB"
- },
- {
-   "name":"Lesotho",
-   "value":"LS"
- },
- {
-   "name":"Liberia",
-   "value":"LR"
- },
- {
-   "name":"Libya",
-   "value":"LY"
- },
- {
-   "name":"Liechtenstein",
-   "value":"LI"
- },
- {
-   "name":"Lithuania",
-   "value":"LT"
- },
- {
-   "name":"Luxembourg",
-   "value":"LU"
- },
- {
-   "name":"Macao",
-   "value":"MO"
- },
- {
-   "name":"Madagascar",
-   "value":"MG"
- },
- {
-   "name":"Malawi",
-   "value":"MW"
- },
- {
-   "name":"Malaysia",
-   "value":"MY"
- },
- {
-   "name":"Maldives",
-   "value":"MV"
- },
- {
-   "name":"Mali",
-   "value":"ML"
- },
- {
-   "name":"Malta",
-   "value":"MT"
- },
- {
-   "name":"Marshall Islands",
-   "value":"MH"
- },
- {
-   "name":"Martinique",
-   "value":"MQ"
- },
- {
-   "name":"Mauritania",
-   "value":"MR"
- },
- {
-   "name":"Mauritius",
-   "value":"MU"
- },
- {
-   "name":"Mayotte",
-   "value":"YT"
- },
- {
-   "name":"Mexico",
-   "value":"MX"
- },
- {
-   "name":"Micronesia, Federated States Of",
-   "value":"FM"
- },
- {
-   "name":"Moldova",
-   "value":"MD"
- },
- {
-   "name":"Monaco",
-   "value":"MC"
- },
- {
-   "name":"Mongolia",
-   "value":"MN"
- },
- {
-   "name":"Montenegro",
-   "value":"ME"
- },
- {
-   "name":"Montserrat",
-   "value":"MS"
- },
- {
-   "name":"Morocco",
-   "value":"MA"
- },
- {
-   "name":"Mozambique",
-   "value":"MZ"
- },
- {
-   "name":"Namibia",
-   "value":"NA"
- },
- {
-   "name":"Nauru",
-   "value":"NR"
- },
- {
-   "name":"Nepal",
-   "value":"NP"
- },
- {
-   "name":"Netherlands",
-   "value":"NL"
- },
- {
-   "name":"Netherlands Antilles",
-   "value":"AN"
- },
- {
-   "name":"New Caledonia",
-   "value":"NC"
- },
- {
-   "name":"New Zealand",
-   "value":"NZ"
- },
- {
-   "name":"Nicaragua",
-   "value":"NI"
- },
- {
-   "name":"Niger",
-   "value":"NE"
- },
- {
-   "name":"Nigeria",
-   "value":"NG"
- },
- {
-   "name":"Niue",
-   "value":"NU"
- },
- {
-   "name":"Norfolk Island",
-   "value":"NF"
- },
- {
-   "name":"North Korea",
-   "value":"KP"
- },
- {
-   "name":"Northern Mariana Islands",
-   "value":"MP"
- },
- {
-   "name":"Norway",
-   "value":"NO"
- },
- {
-   "name":"Oman",
-   "value":"OM"
- },
- {
-   "name":"Pakistan",
-   "value":"PK"
- },
- {
-   "name":"Palau",
-   "value":"PW"
- },
- {
-   "name":"Palestinian Territory, Occupied",
-   "value":"PS"
- },
- {
-   "name":"Panama",
-   "value":"PA"
- },
- {
-   "name":"Papua New Guinea",
-   "value":"PG"
- },
- {
-   "name":"Paraguay",
-   "value":"PY"
- },
- {
-   "name":"Peru",
-   "value":"PE"
- },
- {
-   "name":"Philippines",
-   "value":"PH"
- },
- {
-   "name":"Pitcairn",
-   "value":"PN"
- },
- {
-   "name":"Poland",
-   "value":"PL"
- },
- {
-   "name":"Portugal",
-   "value":"PT"
- },
- {
-   "name":"Puerto Rico",
-   "value":"PR"
- },
- {
-   "name":"Qatar",
-   "value":"QA"
- },
- {
-   "name":"Republic of Macedonia",
-   "value":"MK"
- },
- {
-   "name":"RÉunion",
-   "value":"RE"
- },
- {
-   "name":"Romania",
-   "value":"RO"
- },
- {
-   "name":"Russian Federation",
-   "value":"RU"
- },
- {
-   "name":"Rwanda",
-   "value":"RW"
- },
- {
-   "name":"Saint Helena",
-   "value":"SH"
- },
- {
-   "name":"Saint Kitts And Nevis",
-   "value":"KN"
- },
- {
-   "name":"Saint Lucia",
-   "value":"LC"
- },
- {
-   "name":"Saint Pierre And Miquelon",
-   "value":"PM"
- },
- {
-   "name":"Saint Vincent and the Grenadines",
-   "value":"VC"
- },
- {
-   "name":"Samoa",
-   "value":"WS"
- },
- {
-   "name":"San Marino",
-   "value":"SM"
- },
- {
-   "name":"Sao Tome And Principe",
-   "value":"ST"
- },
- {
-   "name":"Saudi Arabia",
-   "value":"SA"
- },
- {
-   "name":"Saudi–Iraqi neutral zone",
-   "value":"NT"
- },
- {
-   "name":"Senegal",
-   "value":"SN"
- },
- {
-   "name":"Serbia",
-   "value":"RS"
- },
- {
-   "name":"Serbien und Montenegro",
-   "value":"CS"
- },
- {
-   "name":"Seychelles",
-   "value":"SC"
- },
- {
-   "name":"Sierra Leone",
-   "value":"SL"
- },
- {
-   "name":"Singapore",
-   "value":"SG"
- },
- {
-   "name":"Slovakia",
-   "value":"SK"
- },
- {
-   "name":"Slovenia",
-   "value":"SI"
- },
- {
-   "name":"Solomon Islands",
-   "value":"SB"
- },
- {
-   "name":"Somalia",
-   "value":"SO"
- },
- {
-   "name":"South Africa",
-   "value":"ZA"
- },
- {
-   "name":"South Georgia And The South Sandwich Islands",
-   "value":"GS"
- },
- {
-   "name":"South Korea",
-   "value":"KR"
- },
- {
-   "name":"Soviet Union",
-   "value":"SU"
- },
- {
-   "name":"Spain",
-   "value":"ES"
- },
- {
-   "name":"Sri Lanka",
-   "value":"LK"
- },
- {
-   "name":"Sudan",
-   "value":"SD"
- },
- {
-   "name":"Suriname",
-   "value":"SR"
- },
- {
-   "name":"Svalbard And Jan Mayen",
-   "value":"SJ"
- },
- {
-   "name":"Swaziland",
-   "value":"SZ"
- },
- {
-   "name":"Sweden",
-   "value":"SE"
- },
- {
-   "name":"Switzerland",
-   "value":"CH"
- },
- {
-   "name":"Syrian Arab Republic",
-   "value":"SY"
- },
- {
-   "name":"Taiwan",
-   "value":"TW"
- },
- {
-   "name":"Tajikistan",
-   "value":"TJ"
- },
- {
-   "name":"Tanzania, United Republic Of",
-   "value":"TZ"
- },
- {
-   "name":"Thailand",
-   "value":"TH"
- },
- {
-   "name":"The Gambia",
-   "value":"GM"
- },
- {
-   "name":"Togo",
-   "value":"TG"
- },
- {
-   "name":"Tokelau",
-   "value":"TK"
- },
- {
-   "name":"Tonga",
-   "value":"TO"
- },
- {
-   "name":"Trinidad And Tobago",
-   "value":"TT"
- },
- {
-   "name":"Tristan da Cunha",
-   "value":"TA"
- },
- {
-   "name":"Tunisia",
-   "value":"TN"
- },
- {
-   "name":"Turkey",
-   "value":"TR"
- },
- {
-   "name":"Turkmenistan",
-   "value":"TM"
- },
- {
-   "name":"Turks And Caicos Islands",
-   "value":"TC"
- },
- {
-   "name":"Tuvalu",
-   "value":"TV"
- },
- {
-   "name":"Uganda",
-   "value":"UG"
- },
- {
-   "name":"Ukraine",
-   "value":"UA"
- },
- {
-   "name":"United Arab Emirates",
-   "value":"AE"
- },
- {
-   "name":"United Kingdom",
-   "value":"GB"
- },
- {
-   "name":"United States",
-   "value":"US"
- },
- {
-   "name":"Uruguay",
-   "value":"UY"
- },
- {
-   "name":"Uzbekistan",
-   "value":"UZ"
- },
- {
-   "name":"Vanuatu",
-   "value":"VU"
- },
- {
-   "name":"Vatican City",
-   "value":"VA"
- },
- {
-   "name":"Venezuela",
-   "value":"VE"
- },
- {
-   "name":"Viet Nam",
-   "value":"VN"
- },
- {
-   "name":"Virgin Islands, U.s.",
-   "value":"VI"
- },
- {
-   "name":"Wallis And Futuna",
-   "value":"WF"
- },
- {
-   "name":"Western Sahara",
-   "value":"EH"
- },
- {
-   "name":"Yemen",
-   "value":"YE"
- },
- {
-   "name":"Zambia",
-   "value":"ZM"
- },
- {
-   "name":"Zimbabwe",
-   "value":"ZW"
- }
+  {
+    "name": "Afghanistan",
+    "value": "AF"
+  },
+  {
+    "name": "Åland Islands",
+    "value": "AX"
+  },
+  {
+    "name": "Albania",
+    "value": "AL"
+  },
+  {
+    "name": "Algeria",
+    "value": "DZ"
+  },
+  {
+    "name": "American Samoa",
+    "value": "AS"
+  },
+  {
+    "name": "Andorra",
+    "value": "AD"
+  },
+  {
+    "name": "Angola",
+    "value": "AO"
+  },
+  {
+    "name": "Anguilla",
+    "value": "AI"
+  },
+  {
+    "name": "Antarctica",
+    "value": "AQ"
+  },
+  {
+    "name": "Antigua And Barbuda",
+    "value": "AG"
+  },
+  {
+    "name": "Argentina",
+    "value": "AR"
+  },
+  {
+    "name": "Armenia",
+    "value": "AM"
+  },
+  {
+    "name": "Aruba",
+    "value": "AW"
+  },
+  {
+    "name": "Ascension Island",
+    "value": "AC"
+  },
+  {
+    "name": "Australia",
+    "value": "AU"
+  },
+  {
+    "name": "Austria",
+    "value": "AT"
+  },
+  {
+    "name": "Azerbaijan",
+    "value": "AZ"
+  },
+  {
+    "name": "Bahamas",
+    "value": "BS"
+  },
+  {
+    "name": "Bahrain",
+    "value": "BH"
+  },
+  {
+    "name": "Bangladesh",
+    "value": "BD"
+  },
+  {
+    "name": "Barbados",
+    "value": "BB"
+  },
+  {
+    "name": "Belarus",
+    "value": "BY"
+  },
+  {
+    "name": "Belgium",
+    "value": "BE"
+  },
+  {
+    "name": "Belize",
+    "value": "BZ"
+  },
+  {
+    "name": "Benin",
+    "value": "BJ"
+  },
+  {
+    "name": "Bermuda",
+    "value": "BM"
+  },
+  {
+    "name": "Bhutan",
+    "value": "BT"
+  },
+  {
+    "name": "Bolivia",
+    "value": "BO"
+  },
+  {
+    "name": "Bosnia And Herzegovina",
+    "value": "BA"
+  },
+  {
+    "name": "Botswana",
+    "value": "BW"
+  },
+  {
+    "name": "Bouvet Island",
+    "value": "BV"
+  },
+  {
+    "name": "Brazil",
+    "value": "BR"
+  },
+  {
+    "name": "British Indian Ocean Territory",
+    "value": "IO"
+  },
+  {
+    "name": "British Virgin Islands",
+    "value": "VG"
+  },
+  {
+    "name": "Brunei Darussalam",
+    "value": "BN"
+  },
+  {
+    "name": "Bulgaria",
+    "value": "BG"
+  },
+  {
+    "name": "Burkina Faso",
+    "value": "BF"
+  },
+  {
+    "name": "Burma",
+    "value": "MM"
+  },
+  {
+    "name": "Burundi",
+    "value": "BI"
+  },
+  {
+    "name": "Cambodia",
+    "value": "KH"
+  },
+  {
+    "name": "Cameroon",
+    "value": "CM"
+  },
+  {
+    "name": "Canada",
+    "value": "CA"
+  },
+  {
+    "name": "Canary Islands",
+    "value": "IC"
+  },
+  {
+    "name": "Cape Verde",
+    "value": "CV"
+  },
+  {
+    "name": "Cayman Islands",
+    "value": "KY"
+  },
+  {
+    "name": "Central African Republic",
+    "value": "CF"
+  },
+  {
+    "name": "Chad",
+    "value": "TD"
+  },
+  {
+    "name": "Chile",
+    "value": "CL"
+  },
+  {
+    "name": "China",
+    "value": "CN"
+  },
+  {
+    "name": "Christmas Island",
+    "value": "CX"
+  },
+  {
+    "name": "Cocos (keeling) Islands",
+    "value": "CC"
+  },
+  {
+    "name": "Colombia",
+    "value": "CO"
+  },
+  {
+    "name": "Comoros",
+    "value": "KM"
+  },
+  {
+    "name": "Congo",
+    "value": "CG"
+  },
+  {
+    "name": "Congo, The Democratic Republic Of The",
+    "value": "CD"
+  },
+  {
+    "name": "Cook Islands",
+    "value": "CK"
+  },
+  {
+    "name": "Costa Rica",
+    "value": "CR"
+  },
+  {
+    "name": "CÔte D'ivoire",
+    "value": "CI"
+  },
+  {
+    "name": "Croatia",
+    "value": "HR"
+  },
+  {
+    "name": "Cuba",
+    "value": "CU"
+  },
+  {
+    "name": "Cyprus",
+    "value": "CY"
+  },
+  {
+    "name": "Czech Republic",
+    "value": "CZ"
+  },
+  {
+    "name": "Denmark",
+    "value": "DK"
+  },
+  {
+    "name": "Diego Garcia",
+    "value": "DG"
+  },
+  {
+    "name": "Djibouti",
+    "value": "DJ"
+  },
+  {
+    "name": "Dominica",
+    "value": "DM"
+  },
+  {
+    "name": "Dominican Republic",
+    "value": "DO"
+  },
+  {
+    "name": "East Timor",
+    "value": "TL"
+  },
+  {
+    "name": "Ecuador",
+    "value": "EC"
+  },
+  {
+    "name": "Egypt",
+    "value": "EG"
+  },
+  {
+    "name": "El Salvador",
+    "value": "SV"
+  },
+  {
+    "name": "Equatorial Guinea",
+    "value": "GQ"
+  },
+  {
+    "name": "Eritrea",
+    "value": "ER"
+  },
+  {
+    "name": "Estonia",
+    "value": "EE"
+  },
+  {
+    "name": "Ethiopia",
+    "value": "ET"
+  },
+  {
+    "name": "European Union",
+    "value": "EU"
+  },
+  {
+    "name": "Falkland Islands (malvinas)",
+    "value": "FK"
+  },
+  {
+    "name": "Faroe Islands",
+    "value": "FO"
+  },
+  {
+    "name": "Fiji",
+    "value": "FJ"
+  },
+  {
+    "name": "Finland",
+    "value": "FI"
+  },
+  {
+    "name": "France",
+    "value": "FR"
+  },
+  {
+    "name": "French Guiana",
+    "value": "GF"
+  },
+  {
+    "name": "French Polynesia",
+    "value": "PF"
+  },
+  {
+    "name": "French Southern Territories",
+    "value": "TF"
+  },
+  {
+    "name": "Gabon",
+    "value": "GA"
+  },
+  {
+    "name": "Georgia",
+    "value": "GE"
+  },
+  {
+    "name": "Germany",
+    "value": "DE"
+  },
+  {
+    "name": "Ghana",
+    "value": "GH"
+  },
+  {
+    "name": "Gibraltar",
+    "value": "GI"
+  },
+  {
+    "name": "Greece",
+    "value": "GR"
+  },
+  {
+    "name": "Greenland",
+    "value": "GL"
+  },
+  {
+    "name": "Grenada",
+    "value": "GD"
+  },
+  {
+    "name": "Guadeloupe",
+    "value": "GP"
+  },
+  {
+    "name": "Guam",
+    "value": "GU"
+  },
+  {
+    "name": "Guatemala",
+    "value": "GT"
+  },
+  {
+    "name": "Guernsey",
+    "value": "GG"
+  },
+  {
+    "name": "Guinea",
+    "value": "GN"
+  },
+  {
+    "name": "Guinea-Bissau",
+    "value": "GW"
+  },
+  {
+    "name": "Guyana",
+    "value": "GY"
+  },
+  {
+    "name": "Haiti",
+    "value": "HT"
+  },
+  {
+    "name": "Heard Island And Mcdonald Islands",
+    "value": "HM"
+  },
+  {
+    "name": "Honduras",
+    "value": "HN"
+  },
+  {
+    "name": "Hong Kong",
+    "value": "HK"
+  },
+  {
+    "name": "Hungary",
+    "value": "HU"
+  },
+  {
+    "name": "Iceland",
+    "value": "IS"
+  },
+  {
+    "name": "India",
+    "value": "IN"
+  },
+  {
+    "name": "Indonesia",
+    "value": "ID"
+  },
+  {
+    "name": "Iran",
+    "value": "IR"
+  },
+  {
+    "name": "Iraq",
+    "value": "IQ"
+  },
+  {
+    "name": "Ireland",
+    "value": "IE"
+  },
+  {
+    "name": "Isle Of Man",
+    "value": "IM"
+  },
+  {
+    "name": "Israel",
+    "value": "IL"
+  },
+  {
+    "name": "Italy",
+    "value": "IT"
+  },
+  {
+    "name": "Jamaica",
+    "value": "JM"
+  },
+  {
+    "name": "Japan",
+    "value": "JP"
+  },
+  {
+    "name": "Jersey",
+    "value": "JE"
+  },
+  {
+    "name": "Jordan",
+    "value": "JO"
+  },
+  {
+    "name": "Kazakhstan",
+    "value": "KZ"
+  },
+  {
+    "name": "Kenya",
+    "value": "KE"
+  },
+  {
+    "name": "Kiribati",
+    "value": "KI"
+  },
+  {
+    "name": "Kosovo",
+    "value": "XK"
+  },
+  {
+    "name": "Kuwait",
+    "value": "KW"
+  },
+  {
+    "name": "Kyrgyzstan",
+    "value": "KG"
+  },
+  {
+    "name": "Lao People's Democratic Republic",
+    "value": "LA"
+  },
+  {
+    "name": "Latvia",
+    "value": "LV"
+  },
+  {
+    "name": "Lebanon",
+    "value": "LB"
+  },
+  {
+    "name": "Lesotho",
+    "value": "LS"
+  },
+  {
+    "name": "Liberia",
+    "value": "LR"
+  },
+  {
+    "name": "Libya",
+    "value": "LY"
+  },
+  {
+    "name": "Liechtenstein",
+    "value": "LI"
+  },
+  {
+    "name": "Lithuania",
+    "value": "LT"
+  },
+  {
+    "name": "Luxembourg",
+    "value": "LU"
+  },
+  {
+    "name": "Macao",
+    "value": "MO"
+  },
+  {
+    "name": "Madagascar",
+    "value": "MG"
+  },
+  {
+    "name": "Malawi",
+    "value": "MW"
+  },
+  {
+    "name": "Malaysia",
+    "value": "MY"
+  },
+  {
+    "name": "Maldives",
+    "value": "MV"
+  },
+  {
+    "name": "Mali",
+    "value": "ML"
+  },
+  {
+    "name": "Malta",
+    "value": "MT"
+  },
+  {
+    "name": "Marshall Islands",
+    "value": "MH"
+  },
+  {
+    "name": "Martinique",
+    "value": "MQ"
+  },
+  {
+    "name": "Mauritania",
+    "value": "MR"
+  },
+  {
+    "name": "Mauritius",
+    "value": "MU"
+  },
+  {
+    "name": "Mayotte",
+    "value": "YT"
+  },
+  {
+    "name": "Mexico",
+    "value": "MX"
+  },
+  {
+    "name": "Micronesia, Federated States Of",
+    "value": "FM"
+  },
+  {
+    "name": "Moldova",
+    "value": "MD"
+  },
+  {
+    "name": "Monaco",
+    "value": "MC"
+  },
+  {
+    "name": "Mongolia",
+    "value": "MN"
+  },
+  {
+    "name": "Montenegro",
+    "value": "ME"
+  },
+  {
+    "name": "Montserrat",
+    "value": "MS"
+  },
+  {
+    "name": "Morocco",
+    "value": "MA"
+  },
+  {
+    "name": "Mozambique",
+    "value": "MZ"
+  },
+  {
+    "name": "Namibia",
+    "value": "NA"
+  },
+  {
+    "name": "Nauru",
+    "value": "NR"
+  },
+  {
+    "name": "Nepal",
+    "value": "NP"
+  },
+  {
+    "name": "Netherlands",
+    "value": "NL"
+  },
+  {
+    "name": "Netherlands Antilles",
+    "value": "AN"
+  },
+  {
+    "name": "New Caledonia",
+    "value": "NC"
+  },
+  {
+    "name": "New Zealand",
+    "value": "NZ"
+  },
+  {
+    "name": "Nicaragua",
+    "value": "NI"
+  },
+  {
+    "name": "Niger",
+    "value": "NE"
+  },
+  {
+    "name": "Nigeria",
+    "value": "NG"
+  },
+  {
+    "name": "Niue",
+    "value": "NU"
+  },
+  {
+    "name": "Norfolk Island",
+    "value": "NF"
+  },
+  {
+    "name": "North Korea",
+    "value": "KP"
+  },
+  {
+    "name": "Northern Mariana Islands",
+    "value": "MP"
+  },
+  {
+    "name": "Norway",
+    "value": "NO"
+  },
+  {
+    "name": "Oman",
+    "value": "OM"
+  },
+  {
+    "name": "Pakistan",
+    "value": "PK"
+  },
+  {
+    "name": "Palau",
+    "value": "PW"
+  },
+  {
+    "name": "Palestinian Territory, Occupied",
+    "value": "PS"
+  },
+  {
+    "name": "Panama",
+    "value": "PA"
+  },
+  {
+    "name": "Papua New Guinea",
+    "value": "PG"
+  },
+  {
+    "name": "Paraguay",
+    "value": "PY"
+  },
+  {
+    "name": "Peru",
+    "value": "PE"
+  },
+  {
+    "name": "Philippines",
+    "value": "PH"
+  },
+  {
+    "name": "Pitcairn",
+    "value": "PN"
+  },
+  {
+    "name": "Poland",
+    "value": "PL"
+  },
+  {
+    "name": "Portugal",
+    "value": "PT"
+  },
+  {
+    "name": "Puerto Rico",
+    "value": "PR"
+  },
+  {
+    "name": "Qatar",
+    "value": "QA"
+  },
+  {
+    "name": "Republic of Macedonia",
+    "value": "MK"
+  },
+  {
+    "name": "RÉunion",
+    "value": "RE"
+  },
+  {
+    "name": "Romania",
+    "value": "RO"
+  },
+  {
+    "name": "Russian Federation",
+    "value": "RU"
+  },
+  {
+    "name": "Rwanda",
+    "value": "RW"
+  },
+  {
+    "name": "Saint Helena",
+    "value": "SH"
+  },
+  {
+    "name": "Saint Kitts And Nevis",
+    "value": "KN"
+  },
+  {
+    "name": "Saint Lucia",
+    "value": "LC"
+  },
+  {
+    "name": "Saint Pierre And Miquelon",
+    "value": "PM"
+  },
+  {
+    "name": "Saint Vincent and the Grenadines",
+    "value": "VC"
+  },
+  {
+    "name": "Samoa",
+    "value": "WS"
+  },
+  {
+    "name": "San Marino",
+    "value": "SM"
+  },
+  {
+    "name": "Sao Tome And Principe",
+    "value": "ST"
+  },
+  {
+    "name": "Saudi Arabia",
+    "value": "SA"
+  },
+  {
+    "name": "Saudi–Iraqi neutral zone",
+    "value": "NT"
+  },
+  {
+    "name": "Senegal",
+    "value": "SN"
+  },
+  {
+    "name": "Serbia",
+    "value": "RS"
+  },
+  {
+    "name": "Serbien und Montenegro",
+    "value": "CS"
+  },
+  {
+    "name": "Seychelles",
+    "value": "SC"
+  },
+  {
+    "name": "Sierra Leone",
+    "value": "SL"
+  },
+  {
+    "name": "Singapore",
+    "value": "SG"
+  },
+  {
+    "name": "Slovakia",
+    "value": "SK"
+  },
+  {
+    "name": "Slovenia",
+    "value": "SI"
+  },
+  {
+    "name": "Solomon Islands",
+    "value": "SB"
+  },
+  {
+    "name": "Somalia",
+    "value": "SO"
+  },
+  {
+    "name": "South Africa",
+    "value": "ZA"
+  },
+  {
+    "name": "South Georgia And The South Sandwich Islands",
+    "value": "GS"
+  },
+  {
+    "name": "South Korea",
+    "value": "KR"
+  },
+  {
+    "name": "Soviet Union",
+    "value": "SU"
+  },
+  {
+    "name": "Spain",
+    "value": "ES"
+  },
+  {
+    "name": "Sri Lanka",
+    "value": "LK"
+  },
+  {
+    "name": "Sudan",
+    "value": "SD"
+  },
+  {
+    "name": "Suriname",
+    "value": "SR"
+  },
+  {
+    "name": "Svalbard And Jan Mayen",
+    "value": "SJ"
+  },
+  {
+    "name": "Swaziland",
+    "value": "SZ"
+  },
+  {
+    "name": "Sweden",
+    "value": "SE"
+  },
+  {
+    "name": "Switzerland",
+    "value": "CH"
+  },
+  {
+    "name": "Syrian Arab Republic",
+    "value": "SY"
+  },
+  {
+    "name": "Taiwan",
+    "value": "TW"
+  },
+  {
+    "name": "Tajikistan",
+    "value": "TJ"
+  },
+  {
+    "name": "Tanzania, United Republic Of",
+    "value": "TZ"
+  },
+  {
+    "name": "Thailand",
+    "value": "TH"
+  },
+  {
+    "name": "The Gambia",
+    "value": "GM"
+  },
+  {
+    "name": "Togo",
+    "value": "TG"
+  },
+  {
+    "name": "Tokelau",
+    "value": "TK"
+  },
+  {
+    "name": "Tonga",
+    "value": "TO"
+  },
+  {
+    "name": "Trinidad And Tobago",
+    "value": "TT"
+  },
+  {
+    "name": "Tristan da Cunha",
+    "value": "TA"
+  },
+  {
+    "name": "Tunisia",
+    "value": "TN"
+  },
+  {
+    "name": "Turkey",
+    "value": "TR"
+  },
+  {
+    "name": "Turkmenistan",
+    "value": "TM"
+  },
+  {
+    "name": "Turks And Caicos Islands",
+    "value": "TC"
+  },
+  {
+    "name": "Tuvalu",
+    "value": "TV"
+  },
+  {
+    "name": "Uganda",
+    "value": "UG"
+  },
+  {
+    "name": "Ukraine",
+    "value": "UA"
+  },
+  {
+    "name": "United Arab Emirates",
+    "value": "AE"
+  },
+  {
+    "name": "United Kingdom",
+    "value": "GB"
+  },
+  {
+    "name": "United States",
+    "value": "US"
+  },
+  {
+    "name": "Uruguay",
+    "value": "UY"
+  },
+  {
+    "name": "Uzbekistan",
+    "value": "UZ"
+  },
+  {
+    "name": "Vanuatu",
+    "value": "VU"
+  },
+  {
+    "name": "Vatican City",
+    "value": "VA"
+  },
+  {
+    "name": "Venezuela",
+    "value": "VE"
+  },
+  {
+    "name": "Viet Nam",
+    "value": "VN"
+  },
+  {
+    "name": "Virgin Islands, U.s.",
+    "value": "VI"
+  },
+  {
+    "name": "Wallis And Futuna",
+    "value": "WF"
+  },
+  {
+    "name": "Western Sahara",
+    "value": "EH"
+  },
+  {
+    "name": "Worldwide",
+    "value": "WW"
+  },
+  {
+    "name": "Yemen",
+    "value": "YE"
+  },
+  {
+    "name": "Zambia",
+    "value": "ZM"
+  },
+  {
+    "name": "Zimbabwe",
+    "value": "ZW"
+  }
 ]

--- a/country-iso3.json
+++ b/country-iso3.json
@@ -1,1010 +1,1014 @@
 [
- {
-   "name":"Afghanistan",
-   "value":"AFG"
- },
- {
-   "name":"Åland Islands",
-   "value":"ALA"
- },
- {
-   "name":"Albania",
-   "value":"ALB"
- },
- {
-   "name":"Algeria",
-   "value":"DZA"
- },
- {
-   "name":"American Samoa",
-   "value":"ASM"
- },
- {
-   "name":"Andorra",
-   "value":"AND"
- },
- {
-   "name":"Angola",
-   "value":"AGO"
- },
- {
-   "name":"Anguilla",
-   "value":"AIA"
- },
- {
-   "name":"Antarctica",
-   "value":"ATA"
- },
- {
-   "name":"Antigua And Barbuda",
-   "value":"ATG"
- },
- {
-   "name":"Argentina",
-   "value":"ARG"
- },
- {
-   "name":"Armenia",
-   "value":"ARM"
- },
- {
-   "name":"Aruba",
-   "value":"ABW"
- },
- {
-   "name":"Ascension Island",
-   "value":"ASC"
- },
- {
-   "name":"Australia",
-   "value":"AUS"
- },
- {
-   "name":"Austria",
-   "value":"AUT"
- },
- {
-   "name":"Azerbaijan",
-   "value":"AZE"
- },
- {
-   "name":"Bahamas",
-   "value":"BHS"
- },
- {
-   "name":"Bahrain",
-   "value":"BHR"
- },
- {
-   "name":"Bangladesh",
-   "value":"BGD"
- },
- {
-   "name":"Barbados",
-   "value":"BRB"
- },
- {
-   "name":"Belarus",
-   "value":"BLR"
- },
- {
-   "name":"Belgium",
-   "value":"BEL"
- },
- {
-   "name":"Belize",
-   "value":"BLZ"
- },
- {
-   "name":"Benin",
-   "value":"BEN"
- },
- {
-   "name":"Bermuda",
-   "value":"BMU"
- },
- {
-   "name":"Bhutan",
-   "value":"BTN"
- },
- {
-   "name":"Bolivia",
-   "value":"BOL"
- },
- {
-   "name":"Bosnia And Herzegovina",
-   "value":"BIH"
- },
- {
-   "name":"Botswana",
-   "value":"BWA"
- },
- {
-   "name":"Bouvet Island",
-   "value":"BVT"
- },
- {
-   "name":"Brazil",
-   "value":"BRA"
- },
- {
-   "name":"British Indian Ocean Territory",
-   "value":"IOT"
- },
- {
-   "name":"British Virgin Islands",
-   "value":"VGB"
- },
- {
-   "name":"Brunei Darussalam",
-   "value":"BRN"
- },
- {
-   "name":"Bulgaria",
-   "value":"BGR"
- },
- {
-   "name":"Burkina Faso",
-   "value":"BFA"
- },
- {
-   "name":"Burma",
-   "value":"MMR"
- },
- {
-   "name":"Burundi",
-   "value":"BDI"
- },
- {
-   "name":"Cambodia",
-   "value":"KHM"
- },
- {
-   "name":"Cameroon",
-   "value":"CMR"
- },
- {
-   "name":"Canada",
-   "value":"CAN"
- },
- {
-   "name":"Canary Islands",
-   "value":""
- },
- {
-   "name":"Cape Verde",
-   "value":"CPV"
- },
- {
-   "name":"Cayman Islands",
-   "value":"CYM"
- },
- {
-   "name":"Central African Republic",
-   "value":"CAF"
- },
- {
-   "name":"Chad",
-   "value":"TCD"
- },
- {
-   "name":"Chile",
-   "value":"CHL"
- },
- {
-   "name":"China",
-   "value":"CHN"
- },
- {
-   "name":"Christmas Island",
-   "value":"CXR"
- },
- {
-   "name":"Cocos (keeling) Islands",
-   "value":"CCK"
- },
- {
-   "name":"Colombia",
-   "value":"COL"
- },
- {
-   "name":"Comoros",
-   "value":"COM"
- },
- {
-   "name":"Congo",
-   "value":"COG"
- },
- {
-   "name":"Congo, The Democratic Republic Of The",
-   "value":"COD"
- },
- {
-   "name":"Cook Islands",
-   "value":"COK"
- },
- {
-   "name":"Costa Rica",
-   "value":"CRI"
- },
- {
-   "name":"CÔte D'ivoire",
-   "value":"CIV"
- },
- {
-   "name":"Croatia",
-   "value":"HRV"
- },
- {
-   "name":"Cuba",
-   "value":"CUB"
- },
- {
-   "name":"Cyprus",
-   "value":"CYP"
- },
- {
-   "name":"Czech Republic",
-   "value":"CZE"
- },
- {
-   "name":"Denmark",
-   "value":"DNK"
- },
- {
-   "name":"Diego Garcia",
-   "value":"DGA"
- },
- {
-   "name":"Djibouti",
-   "value":"DJI"
- },
- {
-   "name":"Dominica",
-   "value":"DMA"
- },
- {
-   "name":"Dominican Republic",
-   "value":"DOM"
- },
- {
-   "name":"East Timor",
-   "value":"TLS"
- },
- {
-   "name":"Ecuador",
-   "value":"ECU"
- },
- {
-   "name":"Egypt",
-   "value":"EGY"
- },
- {
-   "name":"El Salvador",
-   "value":"SLV"
- },
- {
-   "name":"Equatorial Guinea",
-   "value":"GNQ"
- },
- {
-   "name":"Eritrea",
-   "value":"ERI"
- },
- {
-   "name":"Estonia",
-   "value":"EST"
- },
- {
-   "name":"Ethiopia",
-   "value":"ETH"
- },
- {
-   "name":"European Union",
-   "value":""
- },
- {
-   "name":"Falkland Islands (malvinas)",
-   "value":"FLK"
- },
- {
-   "name":"Faroe Islands",
-   "value":"FRO"
- },
- {
-   "name":"Fiji",
-   "value":"FJI"
- },
- {
-   "name":"Finland",
-   "value":"FIN"
- },
- {
-   "name":"France",
-   "value":"FRA"
- },
- {
-   "name":"French Guiana",
-   "value":"GUF"
- },
- {
-   "name":"French Polynesia",
-   "value":"PYF"
- },
- {
-   "name":"French Southern Territories",
-   "value":"ATF"
- },
- {
-   "name":"Gabon",
-   "value":"GAB"
- },
- {
-   "name":"Georgia",
-   "value":"GEO"
- },
- {
-   "name":"Germany",
-   "value":"DEU"
- },
- {
-   "name":"Ghana",
-   "value":"GHA"
- },
- {
-   "name":"Gibraltar",
-   "value":"GIB"
- },
- {
-   "name":"Greece",
-   "value":"GRC"
- },
- {
-   "name":"Greenland",
-   "value":"GRL"
- },
- {
-   "name":"Grenada",
-   "value":"GRD"
- },
- {
-   "name":"Guadeloupe",
-   "value":"GLP"
- },
- {
-   "name":"Guam",
-   "value":"GUM"
- },
- {
-   "name":"Guatemala",
-   "value":"GTM"
- },
- {
-   "name":"Guernsey",
-   "value":"GGY"
- },
- {
-   "name":"Guinea",
-   "value":"GIN"
- },
- {
-   "name":"Guinea-Bissau",
-   "value":"GNB"
- },
- {
-   "name":"Guyana",
-   "value":"GUY"
- },
- {
-   "name":"Haiti",
-   "value":"HTI"
- },
- {
-   "name":"Heard Island And Mcdonald Islands",
-   "value":"HMD"
- },
- {
-   "name":"Honduras",
-   "value":"HND"
- },
- {
-   "name":"Hong Kong",
-   "value":"HKG"
- },
- {
-   "name":"Hungary",
-   "value":"HUN"
- },
- {
-   "name":"Iceland",
-   "value":"ISL"
- },
- {
-   "name":"India",
-   "value":"IND"
- },
- {
-   "name":"Indonesia",
-   "value":"IDN"
- },
- {
-   "name":"Iran",
-   "value":"IRN"
- },
- {
-   "name":"Iraq",
-   "value":"IRQ"
- },
- {
-   "name":"Ireland",
-   "value":"IRL"
- },
- {
-   "name":"Isle Of Man",
-   "value":"IMN"
- },
- {
-   "name":"Israel",
-   "value":"ISR"
- },
- {
-   "name":"Italy",
-   "value":"ITA"
- },
- {
-   "name":"Jamaica",
-   "value":"JAM"
- },
- {
-   "name":"Japan",
-   "value":"JPN"
- },
- {
-   "name":"Jersey",
-   "value":"JEY"
- },
- {
-   "name":"Jordan",
-   "value":"JOR"
- },
- {
-   "name":"Kazakhstan",
-   "value":"KAZ"
- },
- {
-   "name":"Kenya",
-   "value":"KEN"
- },
- {
-   "name":"Kiribati",
-   "value":"KIR"
- },
- {
-   "name":"Kosovo",
-   "value":"XXK"
- },
- {
-   "name":"Kuwait",
-   "value":"KWT"
- },
- {
-   "name":"Kyrgyzstan",
-   "value":"KGZ"
- },
- {
-   "name":"Lao People's Democratic Republic",
-   "value":"LAO"
- },
- {
-   "name":"Latvia",
-   "value":"LVA"
- },
- {
-   "name":"Lebanon",
-   "value":"LBN"
- },
- {
-   "name":"Lesotho",
-   "value":"LSO"
- },
- {
-   "name":"Liberia",
-   "value":"LBR"
- },
- {
-   "name":"Libya",
-   "value":"LBY"
- },
- {
-   "name":"Liechtenstein",
-   "value":"LIE"
- },
- {
-   "name":"Lithuania",
-   "value":"LTU"
- },
- {
-   "name":"Luxembourg",
-   "value":"LUX"
- },
- {
-   "name":"Macao",
-   "value":"MAC"
- },
- {
-   "name":"Madagascar",
-   "value":"MDG"
- },
- {
-   "name":"Malawi",
-   "value":"MWI"
- },
- {
-   "name":"Malaysia",
-   "value":"MYS"
- },
- {
-   "name":"Maldives",
-   "value":"MDV"
- },
- {
-   "name":"Mali",
-   "value":"MLI"
- },
- {
-   "name":"Malta",
-   "value":"MLT"
- },
- {
-   "name":"Marshall Islands",
-   "value":"MHL"
- },
- {
-   "name":"Martinique",
-   "value":"MTQ"
- },
- {
-   "name":"Mauritania",
-   "value":"MRT"
- },
- {
-   "name":"Mauritius",
-   "value":"MUS"
- },
- {
-   "name":"Mayotte",
-   "value":"MYT"
- },
- {
-   "name":"Mexico",
-   "value":"MEX"
- },
- {
-   "name":"Micronesia, Federated States Of",
-   "value":"FSM"
- },
- {
-   "name":"Moldova",
-   "value":"MDA"
- },
- {
-   "name":"Monaco",
-   "value":"MCO"
- },
- {
-   "name":"Mongolia",
-   "value":"MNG"
- },
- {
-   "name":"Montenegro",
-   "value":"MNE"
- },
- {
-   "name":"Montserrat",
-   "value":"MSR"
- },
- {
-   "name":"Morocco",
-   "value":"MAR"
- },
- {
-   "name":"Mozambique",
-   "value":"MOZ"
- },
- {
-   "name":"Namibia",
-   "value":"NAM"
- },
- {
-   "name":"Nauru",
-   "value":"NRU"
- },
- {
-   "name":"Nepal",
-   "value":"NPL"
- },
- {
-   "name":"Netherlands",
-   "value":"NLD"
- },
- {
-   "name":"Netherlands Antilles",
-   "value":"ANT"
- },
- {
-   "name":"New Caledonia",
-   "value":"NCL"
- },
- {
-   "name":"New Zealand",
-   "value":"NZL"
- },
- {
-   "name":"Nicaragua",
-   "value":"NIC"
- },
- {
-   "name":"Niger",
-   "value":"NER"
- },
- {
-   "name":"Nigeria",
-   "value":"NGA"
- },
- {
-   "name":"Niue",
-   "value":"NIU"
- },
- {
-   "name":"Norfolk Island",
-   "value":"NFK"
- },
- {
-   "name":"North Korea",
-   "value":"PRK"
- },
- {
-   "name":"Northern Mariana Islands",
-   "value":"MNP"
- },
- {
-   "name":"Norway",
-   "value":"NOR"
- },
- {
-   "name":"Oman",
-   "value":"OMN"
- },
- {
-   "name":"Pakistan",
-   "value":"PAK"
- },
- {
-   "name":"Palau",
-   "value":"PLW"
- },
- {
-   "name":"Palestinian Territory, Occupied",
-   "value":"PSE"
- },
- {
-   "name":"Panama",
-   "value":"PAN"
- },
- {
-   "name":"Papua New Guinea",
-   "value":"PNG"
- },
- {
-   "name":"Paraguay",
-   "value":"PRY"
- },
- {
-   "name":"Peru",
-   "value":"PER"
- },
- {
-   "name":"Philippines",
-   "value":"PHL"
- },
- {
-   "name":"Pitcairn",
-   "value":"PCN"
- },
- {
-   "name":"Poland",
-   "value":"POL"
- },
- {
-   "name":"Portugal",
-   "value":"PRT"
- },
- {
-   "name":"Puerto Rico",
-   "value":"PRI"
- },
- {
-   "name":"Qatar",
-   "value":"QAT"
- },
- {
-   "name":"Republic of Macedonia",
-   "value":"MKD"
- },
- {
-   "name":"RÉunion",
-   "value":"REU"
- },
- {
-   "name":"Romania",
-   "value":"ROU"
- },
- {
-   "name":"Russian Federation",
-   "value":"RUS"
- },
- {
-   "name":"Rwanda",
-   "value":"RWA"
- },
- {
-   "name":"Saint Helena",
-   "value":"SHN"
- },
- {
-   "name":"Saint Kitts And Nevis",
-   "value":"KNA"
- },
- {
-   "name":"Saint Lucia",
-   "value":"LCA"
- },
- {
-   "name":"Saint Pierre And Miquelon",
-   "value":"SPM"
- },
- {
-   "name":"Saint Vincent and the Grenadines",
-   "value":"VCT"
- },
- {
-   "name":"Samoa",
-   "value":"WSM"
- },
- {
-   "name":"San Marino",
-   "value":"SMR"
- },
- {
-   "name":"Sao Tome And Principe",
-   "value":"STP"
- },
- {
-   "name":"Saudi Arabia",
-   "value":"SAU"
- },
- {
-   "name":"Saudi–Iraqi neutral zone",
-   "value":"NTZ"
- },
- {
-   "name":"Senegal",
-   "value":"SEN"
- },
- {
-   "name":"Serbia",
-   "value":"SRB"
- },
- {
-   "name":"Serbien und Montenegro",
-   "value":"SCG"
- },
- {
-   "name":"Seychelles",
-   "value":"SYC"
- },
- {
-   "name":"Sierra Leone",
-   "value":"SLE"
- },
- {
-   "name":"Singapore",
-   "value":"SGP"
- },
- {
-   "name":"Slovakia",
-   "value":"SVK"
- },
- {
-   "name":"Slovenia",
-   "value":"SVN"
- },
- {
-   "name":"Solomon Islands",
-   "value":"SLB"
- },
- {
-   "name":"Somalia",
-   "value":"SOM"
- },
- {
-   "name":"South Africa",
-   "value":"ZAF"
- },
- {
-   "name":"South Georgia And The South Sandwich Islands",
-   "value":"SGS"
- },
- {
-   "name":"South Korea",
-   "value":"KOR"
- },
- {
-   "name":"Soviet Union",
-   "value":"SUN"
- },
- {
-   "name":"Spain",
-   "value":"ESP"
- },
- {
-   "name":"Sri Lanka",
-   "value":"LKA"
- },
- {
-   "name":"Sudan",
-   "value":"SDN"
- },
- {
-   "name":"Suriname",
-   "value":"SUR"
- },
- {
-   "name":"Svalbard And Jan Mayen",
-   "value":"SJM"
- },
- {
-   "name":"Swaziland",
-   "value":"SWZ"
- },
- {
-   "name":"Sweden",
-   "value":"SWE"
- },
- {
-   "name":"Switzerland",
-   "value":"CHE"
- },
- {
-   "name":"Syrian Arab Republic",
-   "value":"SYR"
- },
- {
-   "name":"Taiwan",
-   "value":"TWN"
- },
- {
-   "name":"Tajikistan",
-   "value":"TJK"
- },
- {
-   "name":"Tanzania, United Republic Of",
-   "value":"TZA"
- },
- {
-   "name":"Thailand",
-   "value":"THA"
- },
- {
-   "name":"The Gambia",
-   "value":"GMB"
- },
- {
-   "name":"Togo",
-   "value":"TGO"
- },
- {
-   "name":"Tokelau",
-   "value":"TKL"
- },
- {
-   "name":"Tonga",
-   "value":"TON"
- },
- {
-   "name":"Trinidad And Tobago",
-   "value":"TTO"
- },
- {
-   "name":"Tristan da Cunha",
-   "value":"TAA"
- },
- {
-   "name":"Tunisia",
-   "value":"TUN"
- },
- {
-   "name":"Turkey",
-   "value":"TUR"
- },
- {
-   "name":"Turkmenistan",
-   "value":"TKM"
- },
- {
-   "name":"Turks And Caicos Islands",
-   "value":"TCA"
- },
- {
-   "name":"Tuvalu",
-   "value":"TUV"
- },
- {
-   "name":"Uganda",
-   "value":"UGA"
- },
- {
-   "name":"Ukraine",
-   "value":"UKR"
- },
- {
-   "name":"United Arab Emirates",
-   "value":"ARE"
- },
- {
-   "name":"United Kingdom",
-   "value":"GBR"
- },
- {
-   "name":"United States",
-   "value":"USA"
- },
- {
-   "name":"Uruguay",
-   "value":"URY"
- },
- {
-   "name":"Uzbekistan",
-   "value":"UZB"
- },
- {
-   "name":"Vanuatu",
-   "value":"VUT"
- },
- {
-   "name":"Vatican City",
-   "value":"VAT"
- },
- {
-   "name":"Venezuela",
-   "value":"VEN"
- },
- {
-   "name":"Viet Nam",
-   "value":"VNM"
- },
- {
-   "name":"Virgin Islands, U.s.",
-   "value":"VIR"
- },
- {
-   "name":"Wallis And Futuna",
-   "value":"WLF"
- },
- {
-   "name":"Western Sahara",
-   "value":"ESH"
- },
- {
-   "name":"Yemen",
-   "value":"YEM"
- },
- {
-   "name":"Zambia",
-   "value":"ZMB"
- },
- {
-   "name":"Zimbabwe",
-   "value":"ZWE"
- }
+  {
+    "name": "Afghanistan",
+    "value": "AFG"
+  },
+  {
+    "name": "Åland Islands",
+    "value": "ALA"
+  },
+  {
+    "name": "Albania",
+    "value": "ALB"
+  },
+  {
+    "name": "Algeria",
+    "value": "DZA"
+  },
+  {
+    "name": "American Samoa",
+    "value": "ASM"
+  },
+  {
+    "name": "Andorra",
+    "value": "AND"
+  },
+  {
+    "name": "Angola",
+    "value": "AGO"
+  },
+  {
+    "name": "Anguilla",
+    "value": "AIA"
+  },
+  {
+    "name": "Antarctica",
+    "value": "ATA"
+  },
+  {
+    "name": "Antigua And Barbuda",
+    "value": "ATG"
+  },
+  {
+    "name": "Argentina",
+    "value": "ARG"
+  },
+  {
+    "name": "Armenia",
+    "value": "ARM"
+  },
+  {
+    "name": "Aruba",
+    "value": "ABW"
+  },
+  {
+    "name": "Ascension Island",
+    "value": "ASC"
+  },
+  {
+    "name": "Australia",
+    "value": "AUS"
+  },
+  {
+    "name": "Austria",
+    "value": "AUT"
+  },
+  {
+    "name": "Azerbaijan",
+    "value": "AZE"
+  },
+  {
+    "name": "Bahamas",
+    "value": "BHS"
+  },
+  {
+    "name": "Bahrain",
+    "value": "BHR"
+  },
+  {
+    "name": "Bangladesh",
+    "value": "BGD"
+  },
+  {
+    "name": "Barbados",
+    "value": "BRB"
+  },
+  {
+    "name": "Belarus",
+    "value": "BLR"
+  },
+  {
+    "name": "Belgium",
+    "value": "BEL"
+  },
+  {
+    "name": "Belize",
+    "value": "BLZ"
+  },
+  {
+    "name": "Benin",
+    "value": "BEN"
+  },
+  {
+    "name": "Bermuda",
+    "value": "BMU"
+  },
+  {
+    "name": "Bhutan",
+    "value": "BTN"
+  },
+  {
+    "name": "Bolivia",
+    "value": "BOL"
+  },
+  {
+    "name": "Bosnia And Herzegovina",
+    "value": "BIH"
+  },
+  {
+    "name": "Botswana",
+    "value": "BWA"
+  },
+  {
+    "name": "Bouvet Island",
+    "value": "BVT"
+  },
+  {
+    "name": "Brazil",
+    "value": "BRA"
+  },
+  {
+    "name": "British Indian Ocean Territory",
+    "value": "IOT"
+  },
+  {
+    "name": "British Virgin Islands",
+    "value": "VGB"
+  },
+  {
+    "name": "Brunei Darussalam",
+    "value": "BRN"
+  },
+  {
+    "name": "Bulgaria",
+    "value": "BGR"
+  },
+  {
+    "name": "Burkina Faso",
+    "value": "BFA"
+  },
+  {
+    "name": "Burma",
+    "value": "MMR"
+  },
+  {
+    "name": "Burundi",
+    "value": "BDI"
+  },
+  {
+    "name": "Cambodia",
+    "value": "KHM"
+  },
+  {
+    "name": "Cameroon",
+    "value": "CMR"
+  },
+  {
+    "name": "Canada",
+    "value": "CAN"
+  },
+  {
+    "name": "Canary Islands",
+    "value": ""
+  },
+  {
+    "name": "Cape Verde",
+    "value": "CPV"
+  },
+  {
+    "name": "Cayman Islands",
+    "value": "CYM"
+  },
+  {
+    "name": "Central African Republic",
+    "value": "CAF"
+  },
+  {
+    "name": "Chad",
+    "value": "TCD"
+  },
+  {
+    "name": "Chile",
+    "value": "CHL"
+  },
+  {
+    "name": "China",
+    "value": "CHN"
+  },
+  {
+    "name": "Christmas Island",
+    "value": "CXR"
+  },
+  {
+    "name": "Cocos (keeling) Islands",
+    "value": "CCK"
+  },
+  {
+    "name": "Colombia",
+    "value": "COL"
+  },
+  {
+    "name": "Comoros",
+    "value": "COM"
+  },
+  {
+    "name": "Congo",
+    "value": "COG"
+  },
+  {
+    "name": "Congo, The Democratic Republic Of The",
+    "value": "COD"
+  },
+  {
+    "name": "Cook Islands",
+    "value": "COK"
+  },
+  {
+    "name": "Costa Rica",
+    "value": "CRI"
+  },
+  {
+    "name": "CÔte D'ivoire",
+    "value": "CIV"
+  },
+  {
+    "name": "Croatia",
+    "value": "HRV"
+  },
+  {
+    "name": "Cuba",
+    "value": "CUB"
+  },
+  {
+    "name": "Cyprus",
+    "value": "CYP"
+  },
+  {
+    "name": "Czech Republic",
+    "value": "CZE"
+  },
+  {
+    "name": "Denmark",
+    "value": "DNK"
+  },
+  {
+    "name": "Diego Garcia",
+    "value": "DGA"
+  },
+  {
+    "name": "Djibouti",
+    "value": "DJI"
+  },
+  {
+    "name": "Dominica",
+    "value": "DMA"
+  },
+  {
+    "name": "Dominican Republic",
+    "value": "DOM"
+  },
+  {
+    "name": "East Timor",
+    "value": "TLS"
+  },
+  {
+    "name": "Ecuador",
+    "value": "ECU"
+  },
+  {
+    "name": "Egypt",
+    "value": "EGY"
+  },
+  {
+    "name": "El Salvador",
+    "value": "SLV"
+  },
+  {
+    "name": "Equatorial Guinea",
+    "value": "GNQ"
+  },
+  {
+    "name": "Eritrea",
+    "value": "ERI"
+  },
+  {
+    "name": "Estonia",
+    "value": "EST"
+  },
+  {
+    "name": "Ethiopia",
+    "value": "ETH"
+  },
+  {
+    "name": "European Union",
+    "value": ""
+  },
+  {
+    "name": "Falkland Islands (malvinas)",
+    "value": "FLK"
+  },
+  {
+    "name": "Faroe Islands",
+    "value": "FRO"
+  },
+  {
+    "name": "Fiji",
+    "value": "FJI"
+  },
+  {
+    "name": "Finland",
+    "value": "FIN"
+  },
+  {
+    "name": "France",
+    "value": "FRA"
+  },
+  {
+    "name": "French Guiana",
+    "value": "GUF"
+  },
+  {
+    "name": "French Polynesia",
+    "value": "PYF"
+  },
+  {
+    "name": "French Southern Territories",
+    "value": "ATF"
+  },
+  {
+    "name": "Gabon",
+    "value": "GAB"
+  },
+  {
+    "name": "Georgia",
+    "value": "GEO"
+  },
+  {
+    "name": "Germany",
+    "value": "DEU"
+  },
+  {
+    "name": "Ghana",
+    "value": "GHA"
+  },
+  {
+    "name": "Gibraltar",
+    "value": "GIB"
+  },
+  {
+    "name": "Greece",
+    "value": "GRC"
+  },
+  {
+    "name": "Greenland",
+    "value": "GRL"
+  },
+  {
+    "name": "Grenada",
+    "value": "GRD"
+  },
+  {
+    "name": "Guadeloupe",
+    "value": "GLP"
+  },
+  {
+    "name": "Guam",
+    "value": "GUM"
+  },
+  {
+    "name": "Guatemala",
+    "value": "GTM"
+  },
+  {
+    "name": "Guernsey",
+    "value": "GGY"
+  },
+  {
+    "name": "Guinea",
+    "value": "GIN"
+  },
+  {
+    "name": "Guinea-Bissau",
+    "value": "GNB"
+  },
+  {
+    "name": "Guyana",
+    "value": "GUY"
+  },
+  {
+    "name": "Haiti",
+    "value": "HTI"
+  },
+  {
+    "name": "Heard Island And Mcdonald Islands",
+    "value": "HMD"
+  },
+  {
+    "name": "Honduras",
+    "value": "HND"
+  },
+  {
+    "name": "Hong Kong",
+    "value": "HKG"
+  },
+  {
+    "name": "Hungary",
+    "value": "HUN"
+  },
+  {
+    "name": "Iceland",
+    "value": "ISL"
+  },
+  {
+    "name": "India",
+    "value": "IND"
+  },
+  {
+    "name": "Indonesia",
+    "value": "IDN"
+  },
+  {
+    "name": "Iran",
+    "value": "IRN"
+  },
+  {
+    "name": "Iraq",
+    "value": "IRQ"
+  },
+  {
+    "name": "Ireland",
+    "value": "IRL"
+  },
+  {
+    "name": "Isle Of Man",
+    "value": "IMN"
+  },
+  {
+    "name": "Israel",
+    "value": "ISR"
+  },
+  {
+    "name": "Italy",
+    "value": "ITA"
+  },
+  {
+    "name": "Jamaica",
+    "value": "JAM"
+  },
+  {
+    "name": "Japan",
+    "value": "JPN"
+  },
+  {
+    "name": "Jersey",
+    "value": "JEY"
+  },
+  {
+    "name": "Jordan",
+    "value": "JOR"
+  },
+  {
+    "name": "Kazakhstan",
+    "value": "KAZ"
+  },
+  {
+    "name": "Kenya",
+    "value": "KEN"
+  },
+  {
+    "name": "Kiribati",
+    "value": "KIR"
+  },
+  {
+    "name": "Kosovo",
+    "value": "XXK"
+  },
+  {
+    "name": "Kuwait",
+    "value": "KWT"
+  },
+  {
+    "name": "Kyrgyzstan",
+    "value": "KGZ"
+  },
+  {
+    "name": "Lao People's Democratic Republic",
+    "value": "LAO"
+  },
+  {
+    "name": "Latvia",
+    "value": "LVA"
+  },
+  {
+    "name": "Lebanon",
+    "value": "LBN"
+  },
+  {
+    "name": "Lesotho",
+    "value": "LSO"
+  },
+  {
+    "name": "Liberia",
+    "value": "LBR"
+  },
+  {
+    "name": "Libya",
+    "value": "LBY"
+  },
+  {
+    "name": "Liechtenstein",
+    "value": "LIE"
+  },
+  {
+    "name": "Lithuania",
+    "value": "LTU"
+  },
+  {
+    "name": "Luxembourg",
+    "value": "LUX"
+  },
+  {
+    "name": "Macao",
+    "value": "MAC"
+  },
+  {
+    "name": "Madagascar",
+    "value": "MDG"
+  },
+  {
+    "name": "Malawi",
+    "value": "MWI"
+  },
+  {
+    "name": "Malaysia",
+    "value": "MYS"
+  },
+  {
+    "name": "Maldives",
+    "value": "MDV"
+  },
+  {
+    "name": "Mali",
+    "value": "MLI"
+  },
+  {
+    "name": "Malta",
+    "value": "MLT"
+  },
+  {
+    "name": "Marshall Islands",
+    "value": "MHL"
+  },
+  {
+    "name": "Martinique",
+    "value": "MTQ"
+  },
+  {
+    "name": "Mauritania",
+    "value": "MRT"
+  },
+  {
+    "name": "Mauritius",
+    "value": "MUS"
+  },
+  {
+    "name": "Mayotte",
+    "value": "MYT"
+  },
+  {
+    "name": "Mexico",
+    "value": "MEX"
+  },
+  {
+    "name": "Micronesia, Federated States Of",
+    "value": "FSM"
+  },
+  {
+    "name": "Moldova",
+    "value": "MDA"
+  },
+  {
+    "name": "Monaco",
+    "value": "MCO"
+  },
+  {
+    "name": "Mongolia",
+    "value": "MNG"
+  },
+  {
+    "name": "Montenegro",
+    "value": "MNE"
+  },
+  {
+    "name": "Montserrat",
+    "value": "MSR"
+  },
+  {
+    "name": "Morocco",
+    "value": "MAR"
+  },
+  {
+    "name": "Mozambique",
+    "value": "MOZ"
+  },
+  {
+    "name": "Namibia",
+    "value": "NAM"
+  },
+  {
+    "name": "Nauru",
+    "value": "NRU"
+  },
+  {
+    "name": "Nepal",
+    "value": "NPL"
+  },
+  {
+    "name": "Netherlands",
+    "value": "NLD"
+  },
+  {
+    "name": "Netherlands Antilles",
+    "value": "ANT"
+  },
+  {
+    "name": "New Caledonia",
+    "value": "NCL"
+  },
+  {
+    "name": "New Zealand",
+    "value": "NZL"
+  },
+  {
+    "name": "Nicaragua",
+    "value": "NIC"
+  },
+  {
+    "name": "Niger",
+    "value": "NER"
+  },
+  {
+    "name": "Nigeria",
+    "value": "NGA"
+  },
+  {
+    "name": "Niue",
+    "value": "NIU"
+  },
+  {
+    "name": "Norfolk Island",
+    "value": "NFK"
+  },
+  {
+    "name": "North Korea",
+    "value": "PRK"
+  },
+  {
+    "name": "Northern Mariana Islands",
+    "value": "MNP"
+  },
+  {
+    "name": "Norway",
+    "value": "NOR"
+  },
+  {
+    "name": "Oman",
+    "value": "OMN"
+  },
+  {
+    "name": "Pakistan",
+    "value": "PAK"
+  },
+  {
+    "name": "Palau",
+    "value": "PLW"
+  },
+  {
+    "name": "Palestinian Territory, Occupied",
+    "value": "PSE"
+  },
+  {
+    "name": "Panama",
+    "value": "PAN"
+  },
+  {
+    "name": "Papua New Guinea",
+    "value": "PNG"
+  },
+  {
+    "name": "Paraguay",
+    "value": "PRY"
+  },
+  {
+    "name": "Peru",
+    "value": "PER"
+  },
+  {
+    "name": "Philippines",
+    "value": "PHL"
+  },
+  {
+    "name": "Pitcairn",
+    "value": "PCN"
+  },
+  {
+    "name": "Poland",
+    "value": "POL"
+  },
+  {
+    "name": "Portugal",
+    "value": "PRT"
+  },
+  {
+    "name": "Puerto Rico",
+    "value": "PRI"
+  },
+  {
+    "name": "Qatar",
+    "value": "QAT"
+  },
+  {
+    "name": "Republic of Macedonia",
+    "value": "MKD"
+  },
+  {
+    "name": "RÉunion",
+    "value": "REU"
+  },
+  {
+    "name": "Romania",
+    "value": "ROU"
+  },
+  {
+    "name": "Russian Federation",
+    "value": "RUS"
+  },
+  {
+    "name": "Rwanda",
+    "value": "RWA"
+  },
+  {
+    "name": "Saint Helena",
+    "value": "SHN"
+  },
+  {
+    "name": "Saint Kitts And Nevis",
+    "value": "KNA"
+  },
+  {
+    "name": "Saint Lucia",
+    "value": "LCA"
+  },
+  {
+    "name": "Saint Pierre And Miquelon",
+    "value": "SPM"
+  },
+  {
+    "name": "Saint Vincent and the Grenadines",
+    "value": "VCT"
+  },
+  {
+    "name": "Samoa",
+    "value": "WSM"
+  },
+  {
+    "name": "San Marino",
+    "value": "SMR"
+  },
+  {
+    "name": "Sao Tome And Principe",
+    "value": "STP"
+  },
+  {
+    "name": "Saudi Arabia",
+    "value": "SAU"
+  },
+  {
+    "name": "Saudi–Iraqi neutral zone",
+    "value": "NTZ"
+  },
+  {
+    "name": "Senegal",
+    "value": "SEN"
+  },
+  {
+    "name": "Serbia",
+    "value": "SRB"
+  },
+  {
+    "name": "Serbien und Montenegro",
+    "value": "SCG"
+  },
+  {
+    "name": "Seychelles",
+    "value": "SYC"
+  },
+  {
+    "name": "Sierra Leone",
+    "value": "SLE"
+  },
+  {
+    "name": "Singapore",
+    "value": "SGP"
+  },
+  {
+    "name": "Slovakia",
+    "value": "SVK"
+  },
+  {
+    "name": "Slovenia",
+    "value": "SVN"
+  },
+  {
+    "name": "Solomon Islands",
+    "value": "SLB"
+  },
+  {
+    "name": "Somalia",
+    "value": "SOM"
+  },
+  {
+    "name": "South Africa",
+    "value": "ZAF"
+  },
+  {
+    "name": "South Georgia And The South Sandwich Islands",
+    "value": "SGS"
+  },
+  {
+    "name": "South Korea",
+    "value": "KOR"
+  },
+  {
+    "name": "Soviet Union",
+    "value": "SUN"
+  },
+  {
+    "name": "Spain",
+    "value": "ESP"
+  },
+  {
+    "name": "Sri Lanka",
+    "value": "LKA"
+  },
+  {
+    "name": "Sudan",
+    "value": "SDN"
+  },
+  {
+    "name": "Suriname",
+    "value": "SUR"
+  },
+  {
+    "name": "Svalbard And Jan Mayen",
+    "value": "SJM"
+  },
+  {
+    "name": "Swaziland",
+    "value": "SWZ"
+  },
+  {
+    "name": "Sweden",
+    "value": "SWE"
+  },
+  {
+    "name": "Switzerland",
+    "value": "CHE"
+  },
+  {
+    "name": "Syrian Arab Republic",
+    "value": "SYR"
+  },
+  {
+    "name": "Taiwan",
+    "value": "TWN"
+  },
+  {
+    "name": "Tajikistan",
+    "value": "TJK"
+  },
+  {
+    "name": "Tanzania, United Republic Of",
+    "value": "TZA"
+  },
+  {
+    "name": "Thailand",
+    "value": "THA"
+  },
+  {
+    "name": "The Gambia",
+    "value": "GMB"
+  },
+  {
+    "name": "Togo",
+    "value": "TGO"
+  },
+  {
+    "name": "Tokelau",
+    "value": "TKL"
+  },
+  {
+    "name": "Tonga",
+    "value": "TON"
+  },
+  {
+    "name": "Trinidad And Tobago",
+    "value": "TTO"
+  },
+  {
+    "name": "Tristan da Cunha",
+    "value": "TAA"
+  },
+  {
+    "name": "Tunisia",
+    "value": "TUN"
+  },
+  {
+    "name": "Turkey",
+    "value": "TUR"
+  },
+  {
+    "name": "Turkmenistan",
+    "value": "TKM"
+  },
+  {
+    "name": "Turks And Caicos Islands",
+    "value": "TCA"
+  },
+  {
+    "name": "Tuvalu",
+    "value": "TUV"
+  },
+  {
+    "name": "Uganda",
+    "value": "UGA"
+  },
+  {
+    "name": "Ukraine",
+    "value": "UKR"
+  },
+  {
+    "name": "United Arab Emirates",
+    "value": "ARE"
+  },
+  {
+    "name": "United Kingdom",
+    "value": "GBR"
+  },
+  {
+    "name": "United States",
+    "value": "USA"
+  },
+  {
+    "name": "Uruguay",
+    "value": "URY"
+  },
+  {
+    "name": "Uzbekistan",
+    "value": "UZB"
+  },
+  {
+    "name": "Vanuatu",
+    "value": "VUT"
+  },
+  {
+    "name": "Vatican City",
+    "value": "VAT"
+  },
+  {
+    "name": "Venezuela",
+    "value": "VEN"
+  },
+  {
+    "name": "Viet Nam",
+    "value": "VNM"
+  },
+  {
+    "name": "Virgin Islands, U.s.",
+    "value": "VIR"
+  },
+  {
+    "name": "Wallis And Futuna",
+    "value": "WLF"
+  },
+  {
+    "name": "Western Sahara",
+    "value": "ESH"
+  },
+  {
+    "name": "Worldwide",
+    "value": "WWW"
+  },
+  {
+    "name": "Yemen",
+    "value": "YEM"
+  },
+  {
+    "name": "Zambia",
+    "value": "ZMB"
+  },
+  {
+    "name": "Zimbabwe",
+    "value": "ZWE"
+  }
 ]


### PR DESCRIPTION
Even tho it's not actually a country, this entry is needed so that editors could deem a Partner as operating `Worldwide`, so that it will show up when any country is selected.

Link to Slack [discussion](https://storyblok.slack.com/archives/C01KQETU6E6/p1700054752399199)